### PR TITLE
lint: stylelint@14, target src scss instead of built css

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,9 +1,10 @@
 {
-  "extends": "stylelint-config-standard",
+  "extends": "stylelint-config-standard-scss",
   "rules": {
+    "scss/at-import-partial-extension": null,
     "selector-list-comma-newline-after": "always-multi-line",
     "declaration-block-no-duplicate-properties": [true, {
-      ignore: ["consecutive-duplicates-with-different-values"]
+      "ignore": ["consecutive-duplicates-with-different-values"]
     }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "postcss-cli": "^9.1.0",
     "serve": "^13.0.2",
     "sitedown": "^5.0.1",
-    "stylelint": "^7.2.0",
-    "stylelint-config-standard": "^13.0.0",
+    "stylelint": "^14.6.0",
+    "stylelint-config-standard-scss": "^3.0.0",
     "top-bar.css": "^3.0.0"
   },
   "files": [
@@ -61,7 +61,7 @@
     "site:html": "sitedown . -b site/ -l src/site/layout.html --pretty=false",
     "site:release": "cp *.css site",
     "start": "npm-run-all site --parallel serve:*",
-    "test": "stylelint \"style.css\" && stylelint \"serif.css\"",
+    "test": "stylelint \"style.scss\" && stylelint \"serif.scss\"",
     "watch:html": "npm run site:html -- -w",
     "watch:scss": "run-p 'site:css -- -w'",
     "env": "env"

--- a/serif.scss
+++ b/serif.scss
@@ -1,5 +1,5 @@
-@import 'src/scss/fonts.scss';
+@import "./src/scss/fonts.scss";
 
 $font-body: $system-serif;
 
-@import 'style.scss';
+@import "./style.scss";

--- a/style.scss
+++ b/style.scss
@@ -1,25 +1,25 @@
 // variables
 
-@import 'src/scss/fonts';
-@import 'src/scss/colors';
+@import "src/scss/fonts";
+@import "src/scss/colors";
 
 // default settings
 
-$font-body:         $system-sans !default;
-$font-code:         $system-mono !default;
-$font-size-body:    14px !default;
-$font-size-scale:   0.25vw !default;
-$line-height-body:  1.55 !default;
-$line-height-pre:   1.45 !default;
-$link-color:        #0074d9 !default;
+$font-body: $system-sans !default;
+$font-code: $system-mono !default;
+$font-size-body: 14px !default;
+$font-size-scale: 0.25vw !default;
+$line-height-body: 1.55 !default;
+$line-height-pre: 1.45 !default;
+$link-color: #0074d9 !default;
 
 // note: use unitless line heights
 // https://css-tricks.com/almanac/properties/l/line-height/#article-header-id-0
 
-@import 'src/scss/document';
-@import 'src/scss/typography/index';
-@import 'src/scss/embedded';
-@import 'src/scss/forms';
-@import 'src/scss/interactive';
-@import 'src/scss/scripting';
-@import 'src/scss/hidden';
+@import "src/scss/document";
+@import "src/scss/typography/index";
+@import "src/scss/embedded";
+@import "src/scss/forms";
+@import "src/scss/interactive";
+@import "src/scss/scripting";
+@import "src/scss/hidden";


### PR DESCRIPTION
- bump stylelint to 14
- use stylelint-config-standard-scss instead of stylelint-config-standard
- ignore `scss/at-import-partial-extension` rule (breaks postcss autoprefixing)
- lint style.scss & serif.scss, not build artifacts
- run `stylelint --fix` to fix minor linting errors

This should get rid of the last of the vulnerability warnings.

Is it just me or is `npm audit fix` completely broken?