### PR TITLE
chore: rm .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false


### PR DESCRIPTION
- package-lock.json is already ignored in .gitignore
- despite the potential for confusing local dev contributor situations, as a maintainer it's useful to generate a local package-lock.json to be able to quickly audit security warnings
- ∴ I am removing the .npmrc file that disables package-lock